### PR TITLE
alt-key is mod1

### DIFF
--- a/i3/i3-overlay/etc/skel/.config/dunst/dunstrc
+++ b/i3/i3-overlay/etc/skel/.config/dunst/dunstrc
@@ -174,7 +174,7 @@
     history = ctrl+mod4+h 
     
     # Context menu.
-    context = ctrl+alt+c
+    context = ctrl+mod1+c
 
 [urgency_low]
     # IMPORTANT: colors have to be defined in quotation marks.


### PR DESCRIPTION
alt-key should be written as mod1 or ctrl+c will trigger context menu