### PR TITLE
Solid replaces liblxqt-mount

### DIFF
--- a/community/lxqt/Packages-Lxqt
+++ b/community/lxqt/Packages-Lxqt
@@ -34,7 +34,8 @@ compton-conf-git                # compton configuration tool
 
 #keepassx-qt5-git                # passwords managementdd
 liblxqt				#
-liblxqt-mount			# dependencies and libraries for the following lxqt packages
+#liblxqt-mount			# dependencies and libraries for the following lxqt packages
+solid               # replaces liblxqt-mount
 libqtxdg			#
 libsysstat			#
 


### PR DESCRIPTION
Solid replaces liblxqt-mount. See here: https://forum.manjaro.org/index.php?topic=27986.0