### PR TITLE
Fixed 2 packages now in AUR

### DIFF
--- a/community/mate/Packages-Mate
+++ b/community/mate/Packages-Mate
@@ -18,8 +18,8 @@ mate
 mate-extra
 galculator-gtk2
 xterm
-mate-accountsdialog
-mate-disk-utility
+#mate-accountsdialog #AUR
+#mate-disk-utility #AUR
 #manjaro
 manjaro-documentation
 manjaro-mate-settings


### PR DESCRIPTION
Blacklisted 2 packages that are no longer in main repo
mate-accountsdialog 
mate-disk-utility



However can't build image now for this problem:

> error: failed retrieving file 'pluma-1.14.0-1-x86_64.pkg.tar.xz' from mirror.netzspielplatz.de : Maximum file size exceeded

https://forum.manjaro.org/t/pluma-download-maximum-file-size-exceeded/7634/2