### PR TITLE
Packages-Kde: fix hplip dependencies

### DIFF
--- a/official/kde/Packages-Kde
+++ b/official/kde/Packages-Kde
@@ -32,7 +32,12 @@ manjaro-alsa
 manjaro-pulse
 phonon-qt5-gstreamer
 phonon-qt4-gstreamer
+pyqt5-common # For hplip
+python-pillow # For hplip
+python-pip # For hplip
 python-pyqt4  # For pulseaudio gui
+python-pyqt5  # For hplip gui
+python-reportlab # For hplip
 pulseaudio-bluetooth
 pulseaudio-ctl
 pulseaudio-zeroconf


### PR DESCRIPTION
HP Toolbox now is based on QT5, so need python-pyqt5 package.
python-pillow
python-pip
python-reportlab
are additionals for hplip (scan/pdf)