### PR TITLE
Removed obsolete package udisks from Cinnamon and Cinnamon-minimal

### DIFF
--- a/community/cinnamon/Packages-Cinnamon
+++ b/community/cinnamon/Packages-Cinnamon
@@ -99,7 +99,6 @@ p7zip
 parcellite
 pavucontrol
 udiskie
-udisks
 
 ## Package management
 pamac

--- a/minimal/cinnamon-minimal/Packages-Cinnamon
+++ b/minimal/cinnamon-minimal/Packages-Cinnamon
@@ -75,7 +75,6 @@ openssh
 parcellite
 pavucontrol
 udiskie
-udisks
 
 ## Package management
 pamac


### PR DESCRIPTION
Package has been dropped with 2017-01-22 testing update