### PR TITLE
Enable suspend of lid-close / suspend-key.

### DIFF
--- a/community/gnome/gnome-overlay/systemd/logind.conf
+++ b/community/gnome/gnome-overlay/systemd/logind.conf
@@ -18,10 +18,10 @@
 #KillOnlyUsers=
 #KillExcludeUsers=root
 #InhibitDelayMaxSec=5
-#HandlePowerKey=poweroff
-#HandleSuspendKey=ignore
-#HandleHibernateKey=hibernate
-#HandleLidSwitch=suspend
+HandlePowerKey=poweroff
+HandleSuspendKey=suspend
+HandleHibernateKey=hibernate
+HandleLidSwitch=suspend
 #HandleLidSwitchDocked=ignore
 #PowerKeyIgnoreInhibited=no
 #SuspendKeyIgnoreInhibited=no


### PR DESCRIPTION
For me (t440s) suspend on lid-close hasn't worked without that. Is there any reason why this shouldn't be enabled by default?