### PR TITLE
Add gnome-online-accounts so goa works again

### DIFF
--- a/community/gnome/Packages-gnome
+++ b/community/gnome/Packages-gnome
@@ -34,6 +34,7 @@ gnome-terminal
 gnome-themes-standard
 gnome-user-docs
 gnome-user-share
+gnome-online-accounts
 grilo-plugins
 gucharmap
 mousetweaks

--- a/community/gnome/Packages-gnome
+++ b/community/gnome/Packages-gnome
@@ -68,7 +68,8 @@ networkmanager-vpnc
 
 ## Applications
 firefox
-thunderbird
+#thunderbird
+evolution
 uget
 transmission-gtk
 manjaro-browser-settings


### PR DESCRIPTION
I'd additionally propose to add evolution, since it provides a good goa-integration into one single tool instead of (the commented) gnome-contacts etcpp